### PR TITLE
Remove Mods & UX Pass

### DIFF
--- a/MaloWLauncher/HelperFunctions.cs
+++ b/MaloWLauncher/HelperFunctions.cs
@@ -35,7 +35,7 @@ namespace MaloWLauncher
             "UI_bc1",
         });
 
-        public static void LaunchGameWithMod(ModModel mod)
+        public static void UpdateToMod(ModModel mod)
         {
             ConfigFile configFile = ReadConfigFile();
             string dlcFolder = configFile.gameLocation + @"\Assets\DLC\";
@@ -47,8 +47,15 @@ namespace MaloWLauncher
                     Directory.Delete(subdirectory, true);
                 }
             }
-            DirectoryCopy(System.IO.Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + @"\mods\" + mod.Name, dlcFolder);
+            if (mod != null)
+            {
+                DirectoryCopy(System.IO.Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + @"\mods\" + mod.Name, dlcFolder);
+            }
+        }
 
+        public static void LaunchCiv5()
+        {
+            ConfigFile configFile = ReadConfigFile();
             ProcessStartInfo civ5 = new ProcessStartInfo();
             civ5.FileName = configFile.gameLocation + @"\Launcher.exe";
             civ5.Arguments = configFile.launchParameters;

--- a/MaloWLauncher/MainWindow.xaml
+++ b/MaloWLauncher/MainWindow.xaml
@@ -25,7 +25,7 @@
         <Label Content="MaloWLauncher" FontSize="28" Margin="10,0,-10,0"/>
         <Label Name="VersionLabel" Content="{Binding Source={StaticResource SampleVersion}}" FontSize="20" Margin="316,9,-316,-9"/>
         <Button Content="Refresh" Margin="0,10,10,0" Click="Refresh_Clicked" FontSize="20" Height="35" Width="100" VerticalAlignment="Top" HorizontalAlignment="Right"/>
-        <ListView Margin="10,50,10,10" x:Name="ModsList" ItemsSource="{Binding Source={StaticResource SampleMods}}" SizeChanged="ListView_SizeChanged">
+        <ListView Margin="10,50,10,50" x:Name="ModsList" ItemsSource="{Binding Source={StaticResource SampleMods}}" SizeChanged="ListView_SizeChanged">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
                     <Setter Property="Focusable" Value="False"/>
@@ -65,6 +65,8 @@
                 </GridView>
             </ListView.View>
         </ListView>
+        <Button Content="Remove All Mods" Margin="10,50,10,10" Click="RemoveAllMods_Clicked" FontSize="20" Height="35" Width="180" VerticalAlignment="Bottom" HorizontalAlignment="Left"/>
+        <Button Content="Launch Civ 5" Margin="10,50,10,10" Click="LaunchCiv5_Clicked" FontSize="20" Height="35" Width="150" VerticalAlignment="Bottom" HorizontalAlignment="Right"/>
     </Grid>
 </Window>
 

--- a/MaloWLauncher/MainWindow.xaml.cs
+++ b/MaloWLauncher/MainWindow.xaml.cs
@@ -68,13 +68,23 @@ namespace MaloWLauncher
             UpdateModsList(sender, e);
         }
 
+        private void RemoveAllMods_Clicked(object sender, RoutedEventArgs e)
+        {
+            HelperFunctions.UpdateToMod(null);
+        }
+
+        private void LaunchCiv5_Clicked(object sender, RoutedEventArgs e)
+        {
+            HelperFunctions.LaunchCiv5();
+        }
+
         private void ModButton_Clicked(object sender, RoutedEventArgs e)
         {
             Button button = sender as Button;
             ModModel mod = button.DataContext as ModModel;
             if(mod.IsDownloaded)
             {
-                HelperFunctions.LaunchGameWithMod(mod);
+                HelperFunctions.UpdateToMod(mod);
             } else
             {
                 DownloadMod(mod);

--- a/MaloWLauncher/ModModel.cs
+++ b/MaloWLauncher/ModModel.cs
@@ -47,7 +47,7 @@ namespace MaloWLauncher
                     this.IsDownloadedValue = value;
                     if (this.IsDownloadedValue == true)
                     {
-                        this.ButtonText = "Play";
+                        this.ButtonText = "Install";
                     }
                     else
                     {


### PR DESCRIPTION
Updated the launcher with the following:
- Added Remove All Mods button to delete all mods
- Changed "Play" to "Install"
- Added Launch Civ 5 button to launch game instead of mod install
launching it

TODO: remove the Install button when a mod is currently already
installed